### PR TITLE
[WIP]Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
#What
GitのREADME表示を以下分追加
groups_usersテーブル
Association

#Why
GitのREADMEでDBの詳細を分かりやすくする為。